### PR TITLE
fix: set floating numbers difference precision to 1e-4%

### DIFF
--- a/test/test_calc.cpp
+++ b/test/test_calc.cpp
@@ -102,7 +102,7 @@ BOOST_AUTO_TEST_CASE(constant_yaw_velocity )
     BOOST_CHECK_EQUAL( getRoll(vehicle.getPose().orientation), getRoll(orientation));
     BOOST_CHECK_EQUAL( getPitch(vehicle.getPose().orientation), getPitch(orientation));
     //Yaw angle comparison
-    BOOST_CHECK_CLOSE( getYaw(vehicle.getPose().orientation) / getYaw(orientation), 1, 10^-10);
+    BOOST_CHECK_CLOSE( getYaw(vehicle.getPose().orientation) / getYaw(orientation), 1, 1e-4);
 
 }
 
@@ -142,7 +142,7 @@ BOOST_AUTO_TEST_CASE(constant_yaw_velocity_diff_deltaT)
     BOOST_CHECK_EQUAL( getRoll(vehicle.getPose().orientation), getRoll(orientation));
     BOOST_CHECK_EQUAL( getPitch(vehicle.getPose().orientation), getPitch(orientation));
     //Yaw angle comparison
-    BOOST_CHECK_CLOSE( getYaw(vehicle.getPose().orientation) / getYaw(orientation), 1, 10^-10);
+    BOOST_CHECK_CLOSE( getYaw(vehicle.getPose().orientation) / getYaw(orientation), 1, 1e-4);
 
 }
 
@@ -214,10 +214,10 @@ BOOST_AUTO_TEST_CASE( angular )
     for(size_t i=0; i<3; i++)
             BOOST_CHECK_SMALL(error_angles[i], 0.000000000001);
 
-    BOOST_CHECK_CLOSE( getRoll(vehicle.getPose().orientation) / getRoll(final_orientation), 1, 10^-10);
-    BOOST_CHECK_CLOSE( getPitch(vehicle.getPose().orientation) / getPitch(final_orientation), 1, 10^-10);
-    BOOST_CHECK_CLOSE( getYaw(vehicle.getPose().orientation) /  getYaw(final_orientation), 1, 10^-10);
-    BOOST_CHECK_CLOSE(vehicle.getPose().angular_velocity[0] / omega[0], 1, 10^-10 );
+    BOOST_CHECK_CLOSE( getRoll(vehicle.getPose().orientation) / getRoll(final_orientation), 1, 1e-4);
+    BOOST_CHECK_CLOSE( getPitch(vehicle.getPose().orientation) / getPitch(final_orientation), 1, 1e-4);
+    BOOST_CHECK_CLOSE( getYaw(vehicle.getPose().orientation) /  getYaw(final_orientation), 1, 1e-4);
+    BOOST_CHECK_CLOSE(vehicle.getPose().angular_velocity[0] / omega[0], 1, 1e-4 );
 
 }
 


### PR DESCRIPTION
<!--
Depends on:
- [ ]

-->
# What is this PR for
<!-- A clear description of what this PR do and the changes made.
If you want you can also add the shortcut link here
- [ ] [Shortcut](http://) -->
The previous numbers were very greedy, expecting two floating numbers to be at most 1e-10% different from each other. Also `10^-10` is 10 XOR -10, and not 10 to the power of -10.

# Checklist
- [x] Assign yourself  in the PR
- [x] Write unit tests (when relevant)
- [ ] Run rubocop and rake tests locally
- [ ] If this PR initialize a CMAKE package please [enable styling and linting](https://github.com/tidewise/wetpaint-buildconf/blob/master/README.md#enabling-styling-and-linting-checks-for-a-cmake-package)
- [ ] Analyse if this PR modifies the UI, if so:
    - [ ] Tested Tupan's simulation (Charts) :world_map:
    - [ ] Tested Tupan's simulation (Hud) :joystick:
    - [ ] Tested ROV's simulation :joystick:
